### PR TITLE
Add support for package installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
       - master
 
 jobs:
-  test:
+  test_default:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -19,26 +19,59 @@ jobs:
         distro:
           - ubuntu2004
           - ubuntu1804
-          - ubuntu1604
-          - centos7
-          - centos8
-          - debian9
+          # - centos7
+          # - centos8
           - debian10
-          - fedora29
+          - debian11
+          - fedora35
+          # - amazonlinux2
     steps:
       - name: checkout the repository
         uses: actions/checkout@v2
         with:
           path: "${{ github.repository }}"
 
-      - name: run molecule
-        uses: robertdebock/molecule-action@2.6.1
+      - name: run molecule (default scenario)
+        uses: robertdebock/molecule-action@4.0.7
+        with:
+          command: "test"
+        env:
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+
+  test_versioned:
+    needs:
+      - test_default
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - ubuntu2004
+          - ubuntu1804
+          - centos7
+          - centos8
+          - debian10
+          - debian11
+          - fedora35
+          - amazonlinux2
+    steps:
+      - name: checkout the repository
+        uses: actions/checkout@v2
+        with:
+          path: "${{ github.repository }}"
+
+      - name: run molecule (versioned scenario)
+        uses: robertdebock/molecule-action@4.0.7
+        with:
+          scenario: versioned
+          command: "test"
         env:
           MOLECULE_DISTRO: ${{ matrix.distro }}
 
   deploy:
     needs:
-      - test
+      - test_default
+      - test_versioned
     runs-on: ubuntu-latest
     steps:
       - name: to Ansible Galaxy

--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@ Role Variables
 
 These variables are defined in [defaults/main.yml](./defaults/main.yml):
 
-    terraform_architecture: 'amd64'    # enum, one of 386|amd64|arm
+    terraform_plugin_urls: []
+
+Additionally, it is possible to define an explicit version to be downloaded and installed:
 
     terraform_version: '0.12.24'
 
-    terraform_binary_dir_path: "/usr/local/bin"
-
-    terraform_plugin_urls: []
 
 Dependencies
 ------------
@@ -30,6 +29,16 @@ None
 
 Example Playbook
 ----------------
+
+To get a default package:
+
+    - name: Converge
+      hosts: all
+      roles:
+        - role: terraform
+
+
+To get an explicit version:
 
     - name: Converge
       hosts: all

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,3 @@
 ---
 
-terraform_architecture: 'amd64'    # enum, one of 386|amd64|arm
-
-terraform_version: '0.12.24'
-
-terraform_binary_dir_path: "/usr/local/bin"
-
 terraform_plugin_urls: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,7 +24,7 @@ galaxy_info:
         - all
     - name: EL
       versions:
-        - 7
+        - all
 
   galaxy_tags:
     - terraform

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Verify
+  hosts: all
+  tasks:
+    - name: terraform should be installed
+      block:
+        - name: check terraform version
+          command: '/usr/bin/terraform --version'
+          changed_when: false

--- a/molecule/versioned/converge.yml
+++ b/molecule/versioned/converge.yml
@@ -2,8 +2,12 @@
 
 - name: Converge
   hosts: all
+  vars:
+    version: '0.12.24'
   roles:
     - role: ansible-role-terraform
       vars:
+        terraform_version: "{{ version }}"
+        terraform_binary_dir_path: /usr/bin
         terraform_plugin_urls:
           - https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.6.11/terraform-provider-libvirt_0.6.11_linux_amd64.zip

--- a/molecule/versioned/molecule.yml
+++ b/molecule/versioned/molecule.yml
@@ -1,0 +1,22 @@
+---
+
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint -c .yamllint .
+  ansible-lint
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/versioned/prepare.yml
+++ b/molecule/versioned/prepare.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: update apt repository
+      when: "ansible_pkg_mgr == 'apt'"
+      apt:
+        update_cache: true

--- a/molecule/versioned/verify.yml
+++ b/molecule/versioned/verify.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Verify
+  hosts: all
+  vars:
+    version: '0.12.24'
+  tasks:
+    - name: terraform should be installed
+      block:
+        - name: check terraform version
+          command: 'terraform --version'
+          changed_when: false
+          register: r
+          failed_when: not version in r.stdout

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,0 +1,27 @@
+---
+
+- name: establish prerequisites
+  package:
+    name:
+      - gpg-agent
+    state: present
+
+- name: establish repo key
+  become: true
+  ansible.builtin.apt_key:
+    url: https://apt.releases.hashicorp.com/gpg
+    state: present
+
+- name: establish repo
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [arch=amd64] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+    state: present
+    filename: terraform
+
+- name: install package
+  become: true
+  package:
+    name:
+      - terraform
+    state: present

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,42 @@
+---
+
+- name: establish prerequisites
+  become: true
+  vars:
+    prereq:
+      CentOS: yum-utils
+      Fedora: dnf-plugins-core
+      Amazon: yum-utils
+  package:
+    name: "{{ prereq[ansible_facts['distribution']] }}"
+    state: present
+
+- name: establish repo
+  become: true
+  when: ansible_facts['distribution'] in ['CentOS', 'Amazon']
+  vars:
+    type:
+      CentOS: RHEL
+      Amazon: AmazonLinux
+  ansible.builtin.yum_repository:
+    name: hashicorp
+    description: "Hashicorp repository"
+    baseurl: https://rpm.releases.hashicorp.com/{{ type[ansible_facts['distribution']] }}/hashicorp.repo
+    file: hashicorp
+    state: present
+
+- name: establish repo
+  become: true
+  when: ansible_facts['distribution'] in ['Fedora']
+  command:
+    cmd: dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
+    warn: false
+  args:
+    creates: /etc/yum.repos.d/hashicorp.repo
+
+- name: establish package
+  become: true
+  package:
+    name:
+      - terraform
+    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,17 +15,27 @@
   failed_when: false
   tags: install
 
-# from https://terraform.io/downloads.html
-- name: establish (download) binary
-  when: >-
-    v['stdout'] is not defined or
-    terraform_version not in v.stdout
+- name: establish explicit version
+  when:
+    - terraform_version is defined
+    - v['stdout'] is not defined or terraform_version not in v.stdout
+  vars:
+    terraform_architecture: "{{ (ansible_architecture == 'x86_64')
+      | ternary(((ansible_userspace_bits | int) == 64)
+        | ternary('amd64','386'),
+        'arm') | default('amd64') }}"
   become: true
   unarchive:
     src: https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_{{ ansible_system | lower }}_{{ terraform_architecture }}.zip  # noqa 204
     dest: "{{ terraform_binary_dir_path }}"
     remote_src: true
     creates: "{{ terraform_binary_dir_path }}/terraform"
+  tags: install
+
+# https://www.terraform.io/downloads
+- name: install package
+  when: not terraform_version is defined
+  include_tasks: "{{ ansible_os_family }}.yml"
   tags: install
 
 - name: establish plugins

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+---
+
+terraform_binary_dir_path: "/usr/local/bin"


### PR DESCRIPTION
Both explicit version download and latest package scenarios are properly tested. The API has been changed in favor of the packages solution, since Hashicorp Terraform has been promoted to a stable release cycle with stable release mechanisms.